### PR TITLE
Fix microagent validation error not surfaced in UI

### DIFF
--- a/openhands/microagent/microagent.py
+++ b/openhands/microagent/microagent.py
@@ -129,7 +129,7 @@ class TaskMicroAgent(BaseMicroAgent):
 def load_microagents_from_dir(
     microagent_dir: Union[str, Path],
 ) -> tuple[
-    dict[str, RepoMicroAgent], dict[str, KnowledgeMicroAgent], dict[str, TaskMicroAgent]
+    dict[str, RepoMicroAgent], dict[str, KnowledgeMicroAgent], dict[str, TaskMicroAgent], list[str]
 ]:
     """Load all microagents from the given directory.
 
@@ -139,7 +139,7 @@ def load_microagents_from_dir(
         microagent_dir: Path to the microagents directory (e.g. .openhands/microagents)
 
     Returns:
-        Tuple of (repo_agents, knowledge_agents, task_agents) dictionaries
+        Tuple of (repo_agents, knowledge_agents, task_agents, errors) where errors is a list of error messages
     """
     if isinstance(microagent_dir, str):
         microagent_dir = Path(microagent_dir)
@@ -147,6 +147,7 @@ def load_microagents_from_dir(
     repo_agents = {}
     knowledge_agents = {}
     task_agents = {}
+    errors = []
 
     # Load all agents from .openhands/microagents directory
     logger.debug(f'Loading agents from {microagent_dir}')
@@ -166,6 +167,8 @@ def load_microagents_from_dir(
                     task_agents[agent.name] = agent
                 logger.debug(f'Loaded agent {agent.name} from {file}')
             except Exception as e:
-                raise ValueError(f'Error loading agent from {file}: {e}')
+                error_msg = f'Error loading agent from {file}: {e}'
+                logger.error(error_msg)
+                errors.append(error_msg)
 
-    return repo_agents, knowledge_agents, task_agents
+    return repo_agents, knowledge_agents, task_agents, errors


### PR DESCRIPTION
Fixes #6324

This PR addresses the issue where microagent validation errors are logged in the server but not properly displayed in the UI. The changes include:

1. Modified the `load_microagents_from_dir` function to collect errors instead of raising them immediately
2. Updated the `get_microagents_from_selected_repo` method to handle and propagate these errors
3. Updated the agent session to display these errors to the user through the status callback

With these changes, when a microagent has validation errors (like the incorrect type value mentioned in the issue), the error will be properly displayed to the user in the UI.